### PR TITLE
Create native-messaging-hosts directory before Linux install

### DIFF
--- a/native/install/linux_x86_64.sh
+++ b/native/install/linux_x86_64.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+mkdir -p ~/.mozilla/native-messaging-hosts
 curl -L -o ~/.mozilla/native-messaging-hosts/firefox-webserial https://github.com/kuba2k2/firefox-webserial/releases/latest/download/firefox-webserial-linux-x86-64
 chmod +x ~/.mozilla/native-messaging-hosts/firefox-webserial
 cat > ~/.mozilla/native-messaging-hosts/io.github.kuba2k2.webserial.json <<EOL


### PR DESCRIPTION
this happens when `~/.mozilla/native-messaging-hosts` directory does not exist during the first install (linux x86):

```log
Warning: Failed to open the file 
Warning: ~/.mozilla/native-messaging-hosts/firefox-webserial: No 
Warning: such file or directory
  0  150k    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
curl: (23) client returned ERROR on write of 1369 bytes
chmod: cannot access '~/.mozilla/native-messaging-hosts/firefox-webserial': No such file or directory
bash: line 5: ~/.mozilla/native-messaging-hosts/io.github.kuba2k2.webserial.json: No such file or directory
```

creating the folder fixed it for me

