### PR TITLE
Proposed fix for 100% CPU usage when USB device disconnects without explicit port close

### DIFF
--- a/native/src/include.h
+++ b/native/src/include.h
@@ -11,6 +11,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <time.h>
 #include <unistd.h>
 #include <uuid4.h>
 #include <ws.h>

--- a/native/src/serial.c
+++ b/native/src/serial.c
@@ -199,6 +199,10 @@ bool serial_open(serial_port_t *serial, ws_cli_conn_t *conn) {
 }
 
 bool serial_close(serial_port_t *serial) {
+	if (serial->thread != 0) {
+		pthread_cancel(serial->thread);
+		serial->thread = 0;
+	}
 	if (serial->event_set != NULL) {
 		sp_free_event_set(serial->event_set);
 		serial->event_set = NULL;
@@ -207,10 +211,6 @@ bool serial_close(serial_port_t *serial) {
 		sp_close(serial->port);
 		sp_free_port(serial->port);
 		serial->port = NULL;
-	}
-	if (serial->thread != 0) {
-		pthread_cancel(serial->thread);
-		serial->thread = 0;
 	}
 	serial->conn = NULL;
 	return true;

--- a/native/src/websocket.c
+++ b/native/src/websocket.c
@@ -179,11 +179,35 @@ void *websocket_serial_thread(void *arg) {
 		struct sp_port *port = serial->port;
 		if (port == NULL)
 			goto error;
+
+#ifndef _WIN32
+		struct timespec t1, t2;
+		clock_gettime(CLOCK_MONOTONIC, &t1);
+#endif
 		if (sp_wait(serial->event_set, 1000) != SP_OK)
 			goto error;
+#ifndef _WIN32
+		clock_gettime(CLOCK_MONOTONIC, &t2);
+#endif
+
 		int read = sp_nonblocking_read(port, buf + 1, sizeof(buf) - 1);
-		if (read == 0)
+		if (read == 0) {
+#ifdef _WIN32
+			// On Windows, ReadFile on a disconnected COM port returns an
+			// error (→ sp_nonblocking_read < 0) so we should never reach
+			// here on disconnect. Sleep briefly as a safety net.
+			Sleep(10);
+#else
+			// If sp_wait returned in <100ms with no data, the port
+			// is likely disconnected (POLLHUP immediate return).
+			// Exit to avoid a busy-loop at 100% CPU.
+			long elapsed_ms = (t2.tv_sec - t1.tv_sec) * 1000
+			                + (t2.tv_nsec - t1.tv_nsec) / 1000000;
+			if (elapsed_ms < 100)
+				goto error;
+#endif
 			continue;
+		}
 		if (read < 0)
 			goto error;
 		if (serial->conn == NULL)


### PR DESCRIPTION
Full disclosure: this is AI generated patch that works on my Fedora 44 box with Zen browser 1.21.1b (Firefox 151.0.4)

the issue I had was `firefox-webserial` process using 100% CPU and not exiting when closing the browser if there was USB disconnect/reconnect when serial port was in use. I'm working with embedded bootloaders that do this after each firmware upload.

Feel free to disregard in case this is bad code. 'works for my setup' might still be not good enough. Sorry if I wasted your time.

AI summary of cause and fix:

### Root cause

 The reader thread in websocket_serial_thread loops over sp_wait → sp_nonblocking_read. When the device disappears:

 1. The kernel sets POLLHUP on the serial fd.
 2. sp_wait (backed by poll) sees an event and returns immediately (<1 ms) instead of sleeping for the full 1000 ms
 timeout.
 3. sp_nonblocking_read returns 0 bytes — no actual data, just a hangup.
 4. The code treats read == 0 as "try again" and loops. Since sp_wait fires instantly every iteration, this becomes a
 tight busy-loop at 100% CPU.

 The JavaScript side may never call port.close(), so the thread runs forever.

 ### Fix

 Two changes:

 ### 1. Detect POLLHUP by elapsed time (websocket.c)

 A timestamp is taken before and after sp_wait. If it returned in under 100 ms (vs. the normal 1000 ms timeout) and
 there were zero bytes to read, the port is disconnected. The thread exits via the error path instead of spinning.

 Normal idle (no data for 1 second): sp_wait takes ~1000 ms → elapsed >= 100 → continue as before. Unaffected.

 ### 2. Fix serial_close race (serial.c)

 The old code freed the event set and port before cancelling the thread. If the thread was inside sp_wait using those
 resources at that moment, it was a use-after-free. The order is now reversed: cancel thread first, then free
 resources.